### PR TITLE
Link images in slideshow

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,19 +51,19 @@
       <div class="slideshow-wrapper">
       <div class="slideshow">
         <div>
-          <img src="images/p044.png" alt="Dutch ship">
-          <img src="images/p066.png" alt="Diet advice for a healthy sex life">
-          <img src="images/p041.png" alt="Hollander">
+          <a href="http://content.cdlib.org/ark:/13030/hb0w100519/?brand=woodblock"><img src="images/p044.png" alt="Dutch ship"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb9d5nb8g9/?brand=woodblock"><img src="images/p066.png" alt="Diet advice for a healthy sex life"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb6v19p343/?brand=woodblock"><img src="images/p041.png" alt="Hollander"></a>
         </div>
         <div>
-            <img src="images/p282.png" alt="Three drugs from Rakuzendō for heart-burn, constipation, and low energy">
-            <img src="images/p277.png" alt="Easy to use teeth-blackening oxide">
-            <img src="images/p017.png" alt="Defeating measles (personified as a child)">
+          <a href="http://content.cdlib.org/ark:/13030/hb958011gr/?brand=woodblock"><img src="images/p282.png" alt="Three drugs from Rakuzendō for heart-burn, constipation, and low energy"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb600009bd/?brand=woodblock"><img src="images/p277.png" alt="Easy to use teeth-blackening oxide"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb5q2nb5tr/?brand=woodblock"><img src="images/p017.png" alt="Defeating measles (personified as a child)"></a>
         </div>
         <div>
-          <img src="images/p390.png" alt="Internal bodily functions dramatized by popular kabuki actors">
-          <img src="images/p295.png" alt="Base liquid for teeth blackening">
-          <img src="images/p116.png" alt="Hollanders">
+          <a href="http://content.cdlib.org/ark:/13030/hb4r29p1fh/?brand=woodblock"><img src="images/p390.png" alt="Internal bodily functions dramatized by popular kabuki actors"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb3z09p1bz/?brand=woodblock"><img src="images/p295.png" alt="Base liquid for teeth blackening"></a>
+          <a href="http://content.cdlib.org/ark:/13030/hb6h4nb6vr/?brand=woodblock"><img src="images/p116.png" alt="Hollanders"></a>
         </div>
       </div>
     </div>

--- a/styles/slideshow.css
+++ b/styles/slideshow.css
@@ -2,15 +2,16 @@
  * Pretty much lifted from https://snook.ca/archives/html_and_css/simplest-css-slideshow
  */
 @keyframes fade {
-    0% { opacity: 0; }
-    11.11% { opacity: 1; }
-    33.33% { opacity: 1; }
-    44.44% { opacity: 0; }
-    100% { opacity: 0; }
+    0% {  opacity: 0; visibility: hidden; }
+    11.11% { opacity: 1; visibility: visible; }
+    33.33% { opacity: 1; visibility: visible; }
+    44.44% { opacity: 0; visibility: hidden; }
+    100% { opacity: 0; visibility: hidden; }
 }
 
 .slideshow div {
-    opacity:0;
+    opacity: 0;
+    visibility: hidden;
     animation-name: fade;
     animation-duration: 9s;
     animation-iteration-count: infinite;


### PR DESCRIPTION
fixes #12 

please note that this is kinda hinky. 

if you remain moused-over any slides the browser will hold on to the images links from the first slide that you moused-over initially. 
you'll have to mouse-out, then mouse back over in order for the browser to render the correct linkage.

best i can do for now, lmk if you have a better, easy solution that won't require rewriting the slideshow altogether.